### PR TITLE
docs: add WIP notice - action not currently in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Parse Koala Config
 
+> **⚠️ WORK IN PROGRESS - NOT CURRENTLY IN USE**
+>
+> This action is under development and is not yet being used in production. The API and functionality may change without notice.
+
 **Internal Action** - Parses KoalaOps configuration files for workflow generation.
 
 ## Purpose

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Parse Koala Config'
-description: 'Parse koala.yaml/json configuration file for services, environments, and build/deploy settings'
+description: '⚠️ WIP - NOT IN USE. Parse koala.yaml/json configuration file for services, environments, and build/deploy settings'
 author: 'KoalaOps'
 
 branding:


### PR DESCRIPTION
## Summary
- Added clear warning notices to README and action.yml description
- Indicates this action is work in progress and not yet in production use

## Changes
- Added blockquote warning at top of README
- Added ⚠️ WIP prefix to action.yml description

## Rationale
This action is not yet being used and will be kept as-is during the Skyhook rebrand. The WIP notice helps prevent accidental usage.